### PR TITLE
Expose header of table view to allow setting search bar

### DIFF
--- a/LNZTreeView/LNZTreeView.swift
+++ b/LNZTreeView/LNZTreeView.swift
@@ -485,7 +485,7 @@ extension LNZTreeView: UITableViewDelegate {
     }
     
     public func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        guard var nodes = nodesForSection[indexPath.section],
+        guard let nodes = nodesForSection[indexPath.section],
             let indexInParent = self.indexInParent(forNodeAt: indexPath) else {
                 fatalError("Something wrong here")
         }

--- a/LNZTreeView/LNZTreeView.swift
+++ b/LNZTreeView/LNZTreeView.swift
@@ -60,12 +60,21 @@ public class LNZTreeView: UIView {
         get {
             return tableView.keyboardDismissMode
         }
-        set{
+        set {
             tableView.keyboardDismissMode = newValue
         }
     }
     
     public var tableViewRowAnimation: UITableView.RowAnimation = .right
+    
+    public var headerView : UIView? {
+        get {
+            return tableView.tableHeaderView
+        }
+        set {
+            tableView.tableHeaderView = newValue
+        }
+    }
 
     var nodesForSection = [Int: [MinimalTreeNode]]()
     


### PR DESCRIPTION
This change will allow to set UISearchBar to LNZTreeView

For example:
```
    UISearchBar *searchBar = [[UISearchBar alloc] initWithFrame: CGRectMake(0, 0, CGRectGetWidth(self.treeView.frame), 44)];
    self.treeView.headerView = searchBar;

```